### PR TITLE
Prevent crash when no serial port present

### DIFF
--- a/GUI/EvvGC_GUI_v0_4/EvvGC_GUI_v0_4.pde
+++ b/GUI/EvvGC_GUI_v0_4/EvvGC_GUI_v0_4.pde
@@ -90,6 +90,7 @@ void setup()
 
 
 
+  commListMax = -1;
   for(int i=0;i<Serial.list().length;i++) {
     commListMax = i;
   }  


### PR DESCRIPTION
This patch allows the user to launch the app, event if no serial port has been detected.
